### PR TITLE
Fix bug that allows modifying orderStatus to any string

### DIFF
--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -27,12 +27,22 @@ middleware.getOrders = (req, res, next) => {
   return next();
 };
 
-
 middleware.updateOrder = (req, res, next) => {
   if (!req.body.orderStatus) {
     return res.status(400).send({ status: false, message: 'No data was received to update the orderStatus' });
   }
-  req.order = orders.updateOrderStatus(req.params.id, req.body.orderStatus);
+
+  const orderStatus = req.body.orderStatus.toLowerCase();
+
+  const validOrderStatus = ['new', 'processing', 'cancelled', 'complete'];
+  if (!validOrderStatus.includes(orderStatus)) {
+    return res.status(422).send({
+      status: false,
+      message: 'Invalid orderStatus'
+    })
+  }
+
+  req.order = orders.updateOrderStatus(req.params.id, orderStatus);
   if (!req.order) {
     return res.status(404).send({ status: false, message: 'Order does not exist' });
   }

--- a/server/models/order.js
+++ b/server/models/order.js
@@ -6,7 +6,7 @@ export default {
   addOrder(foodId) {
     const meal = menu.findMealById(foodId);
     if (!meal) { return undefined; }
-    const order = { ...meal, id: uniqId(), orderStatus: 'pending' };
+    const order = { ...meal, id: uniqId(), orderStatus: 'new' };
     this.orders.push(order);
     return order;
   },

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -27,7 +27,7 @@ v1.get('/:id', middleware.getOrder, (req, res) => {
 
 // Update order status
 v1.put('/:id', middleware.updateOrder, (req, res) => {
-  res.status(201).send({ status: true, result: req.order, message: `Order status has been updated to ${req.body.orderStatus}` });
+  res.status(200).send({ status: true, result: req.order, message: `Order status has been updated to ${req.body.orderStatus}` });
 });
 
 

--- a/test/routes_test.js
+++ b/test/routes_test.js
@@ -148,6 +148,15 @@ describe('Orders route', () => {
           return done();
         });
     });
+    it('should return 422 for invalid orderStatus', (done) => {
+      chai.request(app)
+        .put('/api/v1/orders/ubeogbasadgweg')
+        .send({ orderStatus: 'wrong string' })
+        .end((err, res) => {
+          expect(res).to.have.status(422);
+          return done();
+        });
+    });
     it('should return 200 and the updated order object', (done) => {
       chai.request(app)
         .put(`/api/v1/orders/${orderId}`)

--- a/test/routes_test.js
+++ b/test/routes_test.js
@@ -134,7 +134,7 @@ describe('Orders route', () => {
     it('should return 404 for incorrect order id', (done) => {
       chai.request(app)
         .put('/api/v1/orders/ubeogbasadgweg')
-        .send({ orderStatus: 'confirmed' })
+        .send({ orderStatus: 'processing' })
         .end((err, res) => {
           expect(res).to.have.status(404);
           return done();
@@ -148,12 +148,12 @@ describe('Orders route', () => {
           return done();
         });
     });
-    it('should return 201 and the updated order object', (done) => {
+    it('should return 200 and the updated order object', (done) => {
       chai.request(app)
         .put(`/api/v1/orders/${orderId}`)
-        .send({ orderStatus: 'confirmed' })
+        .send({ orderStatus: 'processing' })
         .end((err, res) => {
-          expect(res).to.have.status(201);
+          expect(res).to.have.status(200);
           assert.isObject(res.body.result);
           return done();
         });


### PR DESCRIPTION
## This PR fixes a bug that allows setting the orderStatus to any string

### Tasks
* Setup validation to check the orderStatus against an array of allowed values
* Convert the orderStatus to lowercase before comparison
* Return status code 422 if the orderStatus is invalid
* Change the default orderStatus to 'new'

### Steps to reproduce
* Create an order by sending a POST request to:
fast-food-fast-adc.herokuapp.com/api/v1/orders

with the following object in the body
``` javascript
{
    "foodId": "eexbt1qvjlm5nj39"
}
```

* Send a POST request to:
fast-food-fast-adc.herokuapp.com/api/v1/orders/{orderId from first request}

with the following object in the body
``` javascript
{
    "orderStatus": "random characters"
}
```
The orderStatus will change to whatever value you passed in the object

### Pivotal Tracker story
https://www.pivotaltracker.com/story/show/160847942