### PR TITLE
Set a fallback delivery address if user does not provide one

### DIFF
--- a/server/controllers/ordersController.js
+++ b/server/controllers/ordersController.js
@@ -58,7 +58,7 @@ export default {
       });
     }
     const foodIds = req.body.foodIds;
-    const address = req.body.address;
+    const address = req.body.address || req.user.address;
     const queryString = `INSERT INTO 
       orders(user_id, amount, address, food_ids, order_status)
       VALUES('${req.user.id}', '${req.amount}', '${address}', ARRAY[${foodIds}], 'new')

--- a/test/routes_test.js
+++ b/test/routes_test.js
@@ -360,13 +360,12 @@ describe('Orders route', () => {
           return done();
         });
     });
-    it('should return 201 and created object for another user', (done) => {
+    it('should return 201 and created object if no address is provided', (done) => {
       chai.request(app)
         .post('/api/v1/orders')
         .set({ Authorization: `Bearer ${user2token}` })
         .send({ 
-          foodIds: [foodId1],
-          address: 'some place'
+          foodIds: [foodId1]
         })
         .end((err, res) => {
           expect(res).to.have.status(201);


### PR DESCRIPTION
## This PR adds the functionality for the delivery address for an order to default to user address

### Tasks
* Use the address in the user object after token verification as the delivery address if none is provided in the request body

### Pivotal Tracker story

[#160898587](https://www.pivotaltracker.com/story/show/160898587)