### PR TITLE
include address in user object to sign with jwt

### DIFF
--- a/server/controllers/usersController.js
+++ b/server/controllers/usersController.js
@@ -13,7 +13,7 @@ class User {
       text: `INSERT INTO 
         users(firstname, lastname, username, address, phone, password, isadmin) 
         VALUES($1, $2, $3, $4, $5, $6, $7) 
-        RETURNING id, username, isadmin`,
+        RETURNING id, username, isadmin, address`,
       values: [firstname, lastname, username, address, phone, hash, isAdmin],
     };
 
@@ -38,7 +38,7 @@ class User {
 
   static async login(req, res) {
     const { username, password } = req.body;
-    const query = `SELECT id, isadmin, password 
+    const query = `SELECT id, isadmin, password, address
                   FROM users WHERE username = '${username}'`;
 
     try {


### PR DESCRIPTION
## Fixes issue with the delivery address stored as undefined when none is provided

### Steps to reproduce
* Login to the app
* Create an order without including a delivery address

### Cause of bug
The controller uses the user address as part of the signed payload by JWT, but user address was removed from the signed object in this [PR](https://github.com/Tonerolima/Fast-Food-Fast/pull/107)

PT Story
[#161195453](https://www.pivotaltracker.com/story/show/161195453)