### PR TITLE
Remove duplicated class from order list elements

### DIFF
--- a/ui/js/order-history.js
+++ b/ui/js/order-history.js
@@ -78,7 +78,7 @@ const getOrders = () => {
         const created = new Date(order.created_on).toLocaleDateString('en-GB');
         const updated = new Date(order.updated_on).toLocaleDateString('en-GB');
         const {id, amount, order_status, address, food_ids} = order;
-        const item = `<li class="order${order_status} order">
+        const item = `<li class="${order_status} order">
           <div class="raised order-details">
             <p>
               <span class="title">Order id: <span class="value">${id}</span></span>


### PR DESCRIPTION
### Currently
When a user tries to filter their orders by status, no order is displayed on the page

### Suspicion
The class appended on the orders when fetching them from the DB seem to have a duplication and without spacing

### Expected
When a user filters their orders by status by selecting the status from a drop-down, only the orders with that status should be displayed on the screen

PT Story
[#161205596](https://www.pivotaltracker.com/story/show/161205596)