### PR TITLE
Feature add delivery address input #161345163

### DIFF
--- a/ui/cart.html
+++ b/ui/cart.html
@@ -40,6 +40,7 @@
   
     <ul class="vertical list">
       
+      <input id="address_input" class="raised" type="text" placeholder="Enter optional delivery address">
       <div class="section-footer">
         <span>Total: <span id="total"></span></span>
         <button class="large button complete" id="checkout">Checkout</button>

--- a/ui/css/cart.css
+++ b/ui/css/cart.css
@@ -1,3 +1,15 @@
 .card {
   margin-bottom: 10px !important;
 }
+
+#address_input {
+  margin-top: 30px;
+  width: 100%;
+}
+
+.section-footer {
+  align-self: flex-end;
+  margin: 10px 0;
+  display: flex;
+  align-items: center;
+}

--- a/ui/css/index.css
+++ b/ui/css/index.css
@@ -476,13 +476,6 @@ input:focus {
   background: rgb(13, 206, 13);
 }
 
-.section-footer {
-  align-self: flex-end;
-  margin: 30px 0;
-  display: flex;
-  align-items: center;
-}
-
 .small.section {
   max-width: 600px;
   margin: 0 auto;

--- a/ui/js/cart.js
+++ b/ui/js/cart.js
@@ -4,8 +4,13 @@ const checkoutButton = document.getElementById('checkout');
 const addressInput = document.querySelector('#address_input');
 
 document.onreadystatechange = () => {
-  const cart = retrieveCart();
   if (document.readyState === "complete") {
+    const cart = retrieveCart();
+    if (cart.size === 0) {
+      const text = `<div>You have not added any food items to your cart</div>`
+      cartList.innerHTML = text;
+      return;
+    }
     let sum = 0;
     cart.forEach((item, key) => {
       sum += parseInt(item.cost);

--- a/ui/js/cart.js
+++ b/ui/js/cart.js
@@ -1,7 +1,7 @@
 const cartList = document.querySelector('.vertical.list');
 const total = document.getElementById('total');
 const checkoutButton = document.getElementById('checkout');
-const sectionFooter = document.querySelector('.section-footer');
+const addressInput = document.querySelector('#address_input');
 
 document.onreadystatechange = () => {
   const cart = retrieveCart();
@@ -23,7 +23,7 @@ document.onreadystatechange = () => {
         </div>
       </li>
       `;
-      cartList.insertBefore(htmlToElement(node), sectionFooter);
+      cartList.insertBefore(htmlToElement(node), addressInput);
     });
     total.textContent = sum;
   }
@@ -46,8 +46,10 @@ checkoutButton.addEventListener('click', (event) => {
 
 const checkout = (cart) => {
   showLoader('Placing order...');
-  let obj = {};
-  obj.foodIds = [...cart.keys()];
+  let obj = {
+    foodIds: [...cart.keys()],
+    address: addressInput.value.trim(),
+  };
 
   const myInit = { method: 'POST', body: JSON.stringify(obj), headers: { "Content-Type": "application/json", Authorization: `Bearer ${localStorage.authToken}` } };
   const request = new Request('https://fast-food-fast-adc.herokuapp.com/api/v1/orders', myInit);


### PR DESCRIPTION
## Adds an input field in the cart page for an optional delivery address

Currently, there is no input field for delivery address, even though the API is designed to accept an optional address (fallback is the user's registered home address)

### Other tasks
* Adjust section-footer margin from 30px to 10px
* Set cart items to be inserted before address input
* Send delivery address along with foodId array in the post request
* Show message if the cart is empty

### Pivotal Tracker Story
[#161345163](https://www.pivotaltracker.com/story/show/161345163)